### PR TITLE
Qemu/RiscvVirt: Fix timer frequency

### DIFF
--- a/Platform/Qemu/RiscvVirt/RiscvVirt.fdf.inc
+++ b/Platform/Qemu/RiscvVirt/RiscvVirt.fdf.inc
@@ -85,7 +85,7 @@ SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdTemporaryRamSize = 0x10000
 #
 SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdDeviceTreeAddress = 0x1020
 
-SET gUefiRiscVPkgTokenSpaceGuid.PcdRiscVMachineTimerFrequencyInHerz    = 1000000
+SET gUefiRiscVPkgTokenSpaceGuid.PcdRiscVMachineTimerFrequencyInHerz    = 10000000
 # TODO: This can be dynamically configured in QEMU
 SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdHartCount                   = 1          # Total cores on U540 platform
 SET gUefiRiscVPlatformPkgTokenSpaceGuid.PcdBootHartId                  = 0          # Boot hart ID


### PR DESCRIPTION
On Qemu, timer frequency is 10000000. But EDK2 is currently using
1000000. Due to this, the timeout expires much faster.

Signed-off-by: Sunil V L <sunilvl@ventanamicro.com>